### PR TITLE
fix: add clearer "no need to forward ports" hint + price updates for hw

### DIFF
--- a/BeastXUD.md
+++ b/BeastXUD.md
@@ -7,22 +7,22 @@ Two options are available:
 1. **Light setup** using [Neutrino](https://github.com/lightninglabs/neutrino) and a random open eth provider or optionally [Infura](https://infura.io/). This keeps the setup light-weight & cheap, but requires to trust these full nodes delivering correct chain data to a certain extent.
 2. **Full setup** using [bitcoind](https://github.com/bitcoin/bitcoin/), [litecoind](https://github.com/litecoin-project/litecoin) and [geth](https://github.com/ethereum/go-ethereum). Requires more resources and an SSD, but keeps the setup trustless.
 
-## Light Reference Shopping List (Europe): 200 €
-* [GIGABYTE GB-BLCE-4105 BRIX](https://www.computeruniverse.net/en/gigabyte-gb-blce-4105-brix): 148,99 €
-* [4 GB RAM](https://www.computeruniverse.net/en/crucial-4gb-ddr4-so-dimm-ct4g4sfs824a-2400mhz-ram): 20 €
-* [120GB M.2 SSD](https://www.computeruniverse.net/en/wd-green-ssd-m2-2280-120gb): 28 €
+## Light Reference Shopping List (Europe): ~180 €
+* [GIGABYTE GB-BLCE-4105 BRIX](https://www.computeruniverse.net/en/gigabyte-gb-blce-4105-brix): 138 €
+* [4 GB RAM](https://www.computeruniverse.net/en/crucial-4gb-ddr4-so-dimm-ct4g4sfs824a-2400mhz-ram): 15 €
+* [120GB M.2 SSD](https://www.computeruniverse.net/en/wd-green-ssd-m2-2280-120gb): 20 €
 * [USB stick for backups](https://www.amazon.es/dp/B00TPG6P22/): 3,99 €
    * Any >1GB USB stick will do.
    * A NAS/Samba share works too.
 
-## Full Reference Shopping List (Europe): 500 €
-* [GIGABYTE GB-BLCE-4105 BRIX](https://www.computeruniverse.net/en/gigabyte-gb-blce-4105-brix): 148,99 €
-  * Alternative: [ODROID H2+](https://www.hardkernel.com/shop/odroid-h2plus/) - same platform, better specs (NVME), needs separate case + power supply, out of stock at times
-* [32 GB RAM](https://www.computeruniverse.net/en/kingston-hyperx-impact-32gb-ddr4-so-dimm-ram-2): 140 €
+## Full Reference Shopping List (Europe): ~465 €
+* [GIGABYTE GB-BLCE-4105 BRIX](https://www.computeruniverse.net/en/gigabyte-gb-blce-4105-brix): 138 €
+  * Alternative: [ODROID H2+](https://www.hardkernel.com/shop/odroid-h2plus/) - same platform, features NVME, needs separate case, power supply and wifi dongle, out of stock at times
+* [32 GB RAM](https://www.computeruniverse.net/en/kingston-hyperx-impact-32gb-ddr4-so-dimm-ram-2): 127 €
   * Alternative: [List of compatible RAM](https://wiki.odroid.com/odroid-h2/hardware/ram)
-* [2TB SSD](https://www.computeruniverse.net/en/sandisk-ssd-plus-25-2tb): 210 €
+* [2TB SSD](https://www.computeruniverse.net/en/sandisk-ssd-plus-25-2tb): 193 €
   * Alternative: [1 TB M.2 SSD NVME](https://www.computeruniverse.net/en/gigabyte-ssd-nvme-m2-2280-1tb) - for Odroid H2+
-  * Alternative: [240GB M.2 SSD](https://www.computeruniverse.net/en/wd-green-ssd-m2-2280-240gb) + [2TB HDD](https://www.computeruniverse.net/en/seagate-firecuda-compute-st2000lx001-sshd-2tb): 120 €
+  * Alternative: [240GB M.2 SSD](https://www.computeruniverse.net/en/wd-green-ssd-m2-2280-240gb) + [2TB HDD](https://www.computeruniverse.net/en/seagate-firecuda-compute-st2000lx001-sshd-2tb)
 * [USB stick for backups](https://www.amazon.es/dp/B00TPG6P22/): 3,99 €
    * Any >1GB USB stick will do.
    * A NAS/Samba share works too.

--- a/Market Maker Guide.md
+++ b/Market Maker Guide.md
@@ -24,8 +24,8 @@ This guide is written for anyone looking to run xud as a market maker on OpenDEX
 
 ## Hardware
 Since market makers should be online 24/7 and we are ushering in a post-cloud era, we recommend setting up a power-efficient linux box connected to your router. No special configurations, like port forwardings, are necessary. Running your xud setup in the cloud is obviously possible, just not something we encourage to do.
-* **Standard**: Our [RaspiXUD guide](RaspiXUD.md) walks you through setting up a Raspberry Pi3/4. Costs: **70€-300€**
-* **Pro**: Our [BeastXUD guide](BeastXUD.md) walks you through setting up a powerful Mini PC. Costs: **200€-500€**
+* **Standard**: Our [RaspiXUD guide](RaspiXUD.md) walks you through setting up a Raspberry Pi3/4. Costs: **65€-290€**
+* **Pro**: Our [BeastXUD guide](BeastXUD.md) walks you through setting up a powerful Mini PC. Costs: **180€-465€**
 * **Custom**: If you are using a different device or a cloud VPS:
   * Check the hardware requirements for the different networks and modes above
   * The full setup requires a SSD for geth being able to sync. For the light setup, a regular HDD/SD card is fine.
@@ -325,6 +325,7 @@ Re-enter xud-ctl (`bash ~/xud.sh`) and accept the prompt to add arby. You can se
 Please give us feedback and report bugs by running `report` from within `xud ctl` or join our dedicated "market-maker-help" channel on [Discord](https://discord.gg/YgDhMSn)!
 
 # Tips 'n Tricks
+* No need to open/forward ports
 * An overview of all available commands within `xud ctl` can be printed by typing `help` in `xud ctl`. It allows to use client's cli (e.g. `lncli`), check client status, logs and many more.
 * The xud-docker setup uses the fixed home directory `~/.xud-docker` where blockchain & wallet data is stored in by default. Customize the wallet & chain data directory by creating a global xud-docker config file with `cp ~/.xud-docker/sample-xud-docker.conf ~/.xud-docker/xud-docker.conf`, then edit `dir`.
 * All config options can temporary be set via cli parameters; run `bash xud.sh --help` to get an overview of all available parameters. To e.g. use another directory for your mainnet environment, you can run `bash xud.sh --mainnet-dir /path/to/temp/mainnet/dir`.

--- a/RaspiXUD.md
+++ b/RaspiXUD.md
@@ -9,8 +9,8 @@ Two options are available:
 
 If you are not sure, we recommend to start with the light setup. If you opt for the Pi4 4/8GB, you can switch to the full setup at any time.
 
-## Light Reference Shopping List (Spain): 70 €
-* [Pi3 B+](https://www.tiendatec.es/raspberry-pi/placas-base/752-raspberry-pi-3-modelo-b-plus-713179640259.html): 42,95 €
+## Light Reference Shopping List (Spain): ~65 €
+* [Pi3 B+](https://www.tiendatec.es/raspberry-pi/placas-base/752-raspberry-pi-3-modelo-b-plus-713179640259.html): 39,95 €
 * [Pi3 B+ Power Supply](https://www.tiendatec.es/raspberry-pi/raspberry-pi-alimentacion/974-fuente-alimentacion-5v-3a-micro-usb-con-interruptor-raspberry-pi-3-8472496015080.html): 6,65 €
 * [32GB MicroSD card](https://www.amazon.es/dp/B06XYHN68L/): 15 €
   * A performant microSD card is important; not the right place to save some bucks.
@@ -19,10 +19,10 @@ If you are not sure, we recommend to start with the light setup. If you opt for 
    * Any >1GB USB stick will do.
    * A NAS/Samba share works too.
 
-## Full Reference Shopping List (Spain): 308 €
+## Full Reference Shopping List (Spain): ~290 €
 * [Pi4 (8GB)](https://www.tiendatec.es/raspberry-pi/placas-base/1231-raspberry-pi-4-modelo-b-8gb-765756931199.html): 82,95 €
 * [Pi4 Power Supply](https://www.tiendatec.es/raspberry-pi/raspberry-pi-alimentacion/1093-alimentador-oficial-raspberry-pi-4-usb-c-5v-3a-15w-negro-644824914886.html): 8,95 €
-* [Pi4 Cooling Case](https://www.tiendatec.es/raspberry-pi/cajas/1110-caja-cofre-alta-disipacion-con-dos-ventiladores-para-raspberry-pi-4-8472496015950.html): 15,95 €
+* [Pi4 Cooling Case](https://www.tiendatec.es/raspberry-pi/cajas/1110-caja-cofre-alta-disipacion-con-dos-ventiladores-para-raspberry-pi-4-8472496015950.html): 14,95 €
   * Needed! The Pi4 is a hottie.
 * [32GB MicroSD card](https://www.amazon.es/dp/B06XYHN68L/): 15 €
   * A performant microSD card is important; not the right place to save some bucks.
@@ -30,7 +30,7 @@ If you are not sure, we recommend to start with the light setup. If you opt for 
 * [USB stick for backups](https://www.amazon.es/dp/B00TPG6P22/): 3,99 €
    * Any >1GB USB stick will do.
    * A NAS/Samba share works too.
-* [1TB external SSD](https://www.amazon.es/gp/product/B074M774TW/): 180 €
+* [1TB external SSD](https://www.amazon.es/gp/product/B074M774TW/): 165 €
   * **For full setup only, not needed for light setup!**
   * For more options, check [this storage benchmark list](https://jamesachambers.com/raspberry-pi-storage-benchmarks/).
 


### PR DESCRIPTION
- added ["no need to forward ports" hint](https://github.com/ExchangeUnion/docs/compare/develop?expand=1#diff-c98f78084ebefed2e59966bae0a2fc06R328) to the "Tips 'n Tricks" section as feedback by @jgarzik
- updated prices of hardware